### PR TITLE
Block Format

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -7,6 +7,8 @@ if(${PROJECT_NAME} STREQUAL "YARC")
 		target_link_libraries(yarc yarc-lz4-hc)
 	endif()
 
+	target_link_libraries(yarc yarc-api)
+
 else()
 	cmake_minimum_required(VERSION 3.0)
 
@@ -19,8 +21,10 @@ else()
 		set(YARC_EXTRA_SOURCES
 			../external/lz4/lz4.c
 			../external/lz4/lz4hc.c)
-	endif()	
+	endif()
 
 	add_executable(yarc yarc.c ${YARC_EXTRA_SOURCES})
+
+	target_link_libraries(yarc yarc-api)
 endif()
 

--- a/app/yarc.c
+++ b/app/yarc.c
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <yarc/yarc.h>
+
 #ifndef _WIN32
 #define _strdup strdup
 #else
@@ -42,6 +44,7 @@ static char* yarc_version = "1.0.0";
 static bool yarc_static = false;
 static bool yarc_verbose = false;
 static bool yarc_compress = false;
+static bool yarc_block = false;
 
 #ifndef YARC_LZ4
 int LZ4_compress_HC(const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel) { return 0; }
@@ -203,6 +206,27 @@ int yarc_zdata_write(yarc_file_t* out, const uint8_t* zdata, size_t zsize, size_
 	return 1;
 }
 
+size_t yarc_string_size(const char* str)
+{
+	size_t len, pad, size;
+	len = str ? strlen(str) : 0;
+	size = (2 + len + 1);
+	pad = ((size + 3) & ~0x3) - size;
+	return (size + pad);
+}
+
+size_t yarc_string_write(uint8_t* ptr, const char* str)
+{
+	size_t len, pad, size;
+	len = str ? strlen(str) : 0;
+	size = (2 + len + 1);
+	pad = ((size + 3) & ~0x3) - size;
+	*((uint16_t*) &ptr[0]) = (uint16_t) len;
+	memcpy(&ptr[2], str, len + 1);
+	memset(&ptr[size], 0, pad);
+	return (size + pad);
+}
+
 int yarc_file_load(yarc_file_t* yf)
 {
 	yf->fp = fopen(yf->filename, "rb");
@@ -311,6 +335,7 @@ void yarc_print_help()
 		"    -u                use uppercase hex (default is lowercase)\n"
 		"    -s                use static keyword on resources\n"
 		"    -z                use bundle compression (lz4)\n"
+		"    -k                use block format\n"
 		"    -h                print help\n"
 		"    -v                print version (%s)\n"
 		"    -V                verbose mode\n"
@@ -410,6 +435,10 @@ int main(int argc, char** argv)
 					yarc_compress = true;
 					break;
 
+				case 'k':
+					yarc_block = true;
+					break;
+
 				case 'h':
 					yarc_print_help();
 					break;
@@ -425,6 +454,9 @@ int main(int argc, char** argv)
 
 			continue;
 		}
+
+		if (yarc_block && !strcmp(yarc_output, "resources.c"))
+			yarc_output = "resources.yarc";
 
 		file = &files[nfiles++];
 		file->filename = _strdup(argv[index]);
@@ -493,7 +525,7 @@ int main(int argc, char** argv)
 			memcpy(&data[file->offset], file->data, file->size + yarc_padding);
 		}
 
-		zstatus = LZ4_compress_HC((const char*) data, (char*) zdata, size, zsize, 12);
+		zstatus = LZ4_compress_HC((const char*) data, (char*) zdata, (int) size, (int) zsize, 12);
 
 		if (zstatus < 1)
 		{
@@ -516,75 +548,140 @@ int main(int argc, char** argv)
 
 	/* start generating resource bundle file */
 
-	fprintf(out->fp, "\n");
-
-	for (index = 0; index < nfiles; index++)
+	if (yarc_block)
 	{
-		file = &files[index];
+		uint8_t* ptr;
+		size_t blockSize;
+		uint8_t* blockData;
 
-		status = yarc_file_write(out, file);
+		blockSize = 24 + yarc_string_size(yarc_bundle);
 
-		if (status < 1)
+		for (index = 0; index < nfiles; index++)
+		{
+			file = &files[index];
+			blockSize += 8 + yarc_string_size(file->basename);
+		}
+
+		blockSize = (blockSize + 15) & ~0xF;
+
+		blockData = (uint8_t*) malloc(blockSize);
+
+		if (!blockData)
 			return 1;
-	}
 
-	if (yarc_compress)
-	{
-		status = yarc_zdata_write(out, zdata, zsize, size);
+		ptr = blockData;
 
-		if (status < 1)
+		*((uint32_t*) &ptr[0]) = YARC_MAGIC;		/* magic, 0x43524159, "YARC" */
+		*((uint32_t*) &ptr[4]) = (uint32_t) blockSize;	/* payload data offset */
+		*((uint32_t*) &ptr[8]) = (uint32_t) size;	/* uncompressed data size */
+		*((uint32_t*) &ptr[12]) = (uint32_t) zsize;	/* compressed data size */
+		*((uint32_t*) &ptr[16]) = (uint32_t) nfiles;	/* number of resources */
+		*((uint32_t*) &ptr[20]) = (uint32_t) 0;		/* flags (reserved) */
+		ptr += 24;
+
+		ptr += yarc_string_write(ptr, yarc_bundle);
+
+		for (index = 0; index < nfiles; index++)
+		{
+			file = &files[index];
+
+			*((uint32_t*) &ptr[0]) = (uint32_t) file->offset;
+			*((uint32_t*) &ptr[4]) = (uint32_t) file->size;
+			ptr += 8;
+
+			ptr += yarc_string_write(ptr, file->basename);
+		}
+
+		memset(ptr, 0, blockSize - (ptr - blockData));
+
+		if (fwrite(blockData, 1, blockSize, out->fp) != blockSize)
 			return 1;
-	}
 
-	fprintf(out->fp,
-		"typedef struct {\n"
-		"  const char* name;\n"
-		"  const unsigned int* size;\n"
-		"  const unsigned char** data;\n"
-		"  const unsigned int offset;\n"
-		"} %s_resource_t;\n\n", yarc_prefix);
+		if (yarc_compress)
+		{
+			if (fwrite(zdata, 1, zsize, out->fp) != zsize)
+				return 1;
+		}
+		else
+		{
+			if (fwrite(data, 1, size, out->fp) != size)
+				return 1;
+		}
 
-	fprintf(out->fp,
-		"typedef struct {\n"
-		"  const char* name;\n"
-		"  const unsigned int size;\n"
-		"  const unsigned char* data;\n"
-		"  const unsigned int zsize;\n"
-		"  const unsigned char* zdata;\n"
-		"  const %s_resource_t* resources;\n"
-		"} %s_bundle_t;\n\n", yarc_prefix, yarc_prefix);
-
-	fprintf(out->fp, "%sconst %s_resource_t %s_%s_resources[] = {\n",
-		yarc_static ? "static " : "",
-		yarc_prefix, yarc_prefix, yarc_bundle);
-
-	for (index = 0; index < nfiles; index++)
-	{
-		file = &files[index];
-		fprintf(out->fp, "  { \"%s\", &%s_size, &%s_data, %d },\n",
-			file->basename, file->identifier, file->identifier, (int) file->offset);
-	}
-
-	fprintf(out->fp, "  { \"\", 0, 0 }\n};\n");
-	fprintf(out->fp, "\n");
-
-	fprintf(out->fp, "%s%s_bundle_t %s_%s_bundle = {\n",
-		yarc_static ? "static " : "",
-		yarc_prefix, yarc_prefix, yarc_bundle);
-
-	if (yarc_compress)
-	{
-		fprintf(out->fp, "  \"%s\", %d, 0, %d, %s_%s_zdata, %s_%s_resources\n",
-			yarc_bundle, (int) size, (int) zsize, yarc_prefix, yarc_bundle, yarc_prefix, yarc_bundle);
+		free(blockData);
 	}
 	else
 	{
-		fprintf(out->fp, "  \"%s\", %d, 0, %d, 0, %s_%s_resources\n",
-			yarc_bundle, (int) size, (int) zsize, yarc_prefix, yarc_bundle);
-	}
+		fprintf(out->fp, "\n");
 
-	fprintf(out->fp, "};\n");
-	fprintf(out->fp, "\n");
+		for (index = 0; index < nfiles; index++)
+		{
+			file = &files[index];
+
+			status = yarc_file_write(out, file);
+
+			if (status < 1)
+				return 1;
+		}
+
+		if (yarc_compress)
+		{
+			status = yarc_zdata_write(out, zdata, zsize, size);
+
+			if (status < 1)
+				return 1;
+		}
+
+		fprintf(out->fp,
+			"typedef struct {\n"
+			"  const char* name;\n"
+			"  const unsigned int* size;\n"
+			"  const unsigned char** data;\n"
+			"  const unsigned int offset;\n"
+			"} %s_resource_t;\n\n", yarc_prefix);
+
+		fprintf(out->fp,
+			"typedef struct {\n"
+			"  const char* name;\n"
+			"  const unsigned int size;\n"
+			"  const unsigned char* data;\n"
+			"  const unsigned int zsize;\n"
+			"  const unsigned char* zdata;\n"
+			"  const %s_resource_t* resources;\n"
+			"} %s_bundle_t;\n\n", yarc_prefix, yarc_prefix);
+
+		fprintf(out->fp, "%sconst %s_resource_t %s_%s_resources[] = {\n",
+			yarc_static ? "static " : "",
+			yarc_prefix, yarc_prefix, yarc_bundle);
+
+		for (index = 0; index < nfiles; index++)
+		{
+			file = &files[index];
+			fprintf(out->fp, "  { \"%s\", &%s_size, &%s_data, %d },\n",
+				file->basename, file->identifier, file->identifier, (int) file->offset);
+		}
+
+		fprintf(out->fp, "  { \"\", 0, 0 }\n};\n");
+		fprintf(out->fp, "\n");
+
+		fprintf(out->fp, "%s%s_bundle_t %s_%s_bundle = {\n",
+			yarc_static ? "static " : "",
+			yarc_prefix, yarc_prefix, yarc_bundle);
+
+		if (yarc_compress)
+		{
+			fprintf(out->fp, "  \"%s\", %d, 0, %d, %s_%s_zdata, %s_%s_resources\n",
+				yarc_bundle, (int) size, (int) zsize, yarc_prefix, yarc_bundle, yarc_prefix, yarc_bundle);
+		}
+		else
+		{
+			fprintf(out->fp, "  \"%s\", %d, 0, %d, 0, %s_%s_resources\n",
+				yarc_bundle, (int) size, (int) zsize, yarc_prefix, yarc_bundle);
+		}
+
+		fprintf(out->fp, "};\n");
+		fprintf(out->fp, "\n");
+	}
 
 	yarc_file_close(out);
 	free(files);

--- a/include/yarc/yarc.h
+++ b/include/yarc/yarc.h
@@ -30,20 +30,22 @@ extern "C" {
 #endif
 
 typedef struct {
-  const char* name;
-  const unsigned int* size;
-  const unsigned char** data;
-  const unsigned int offset;
+	const char* name;
+	const unsigned int* size;
+	const unsigned char** data;
+	const unsigned int offset;
 } yarc_resource_t;
 
 typedef struct {
-  const char* name;
-  const unsigned int size;
-  const unsigned char* data;
-  const unsigned int zsize;
-  const unsigned char* zdata;
-  const yarc_resource_t* resources;
+	const char* name;
+	const unsigned int size;
+	const unsigned char* data;
+	const unsigned int zsize;
+	const unsigned char* zdata;
+	const yarc_resource_t* resources;
 } yarc_bundle_t;
+
+#define YARC_MAGIC	0x43524159
 
 const unsigned char* yarc_bundle_find(yarc_bundle_t* bundle, const char* name, int* size);
 

--- a/include/yarc/yarc.h
+++ b/include/yarc/yarc.h
@@ -47,10 +47,21 @@ typedef struct {
 
 #define YARC_MAGIC	0x43524159
 
+typedef struct yarc_block_s yarc_block_t;
+
 const unsigned char* yarc_bundle_find(yarc_bundle_t* bundle, const char* name, int* size);
 
 bool yarc_bundle_open(yarc_bundle_t* bundle);
 bool yarc_bundle_close(yarc_bundle_t* bundle);
+
+const char* yarc_block_name(yarc_block_t* block);
+uint32_t yarc_block_count(yarc_block_t* block);
+
+const uint8_t* yarc_block_entry(yarc_block_t* block, uint32_t index, uint32_t* size, const char** name);
+const uint8_t* yarc_block_find(yarc_block_t* block, const char* name, uint32_t* size);
+
+yarc_block_t* yarc_block_open(const uint8_t* data, size_t size);
+void yarc_block_close(yarc_block_t* block);
 
 #ifdef __cplusplus
 }

--- a/libyarc/yarc.c
+++ b/libyarc/yarc.c
@@ -82,3 +82,193 @@ bool yarc_bundle_close(yarc_bundle_t* bundle)
 	return true;
 }
 
+typedef struct {
+	uint32_t offset;
+	uint32_t size;
+	const char* name;
+	uint8_t* data;
+} yarc_entry_t;
+
+struct yarc_block_s {
+	uint32_t magic;
+	uint32_t offset;
+	uint32_t size;
+	uint32_t zsize;
+	uint32_t count;
+	uint32_t flags;
+	const char* name;
+	yarc_entry_t* entries;
+	uint8_t* data;
+};
+
+size_t yarc_string_read(const uint8_t* data, size_t size, const char** str)
+{
+	uint16_t len;
+
+	*str = "";
+
+	if (size < 3)
+		return 0;
+
+	len = *((uint16_t*) data);
+
+	if (((size_t) len) > (size - 3))
+		return 0;
+
+	if (data[2 + len] != '\0')
+		return 0;
+
+	*str = (const char*) &data[2];
+
+	return ((2 + ((size_t) len) + 1) + 3) & ~0x3;
+}
+
+const char* yarc_block_name(yarc_block_t* block)
+{
+	if (!block)
+		return "";
+
+	return block->name;
+}
+
+uint32_t yarc_block_count(yarc_block_t* block)
+{
+	if (!block)
+		return 0;
+
+	return block->count;
+}
+
+const uint8_t* yarc_block_entry(yarc_block_t* block, uint32_t index, uint32_t* size, const char** name)
+{
+	yarc_entry_t* entry;
+
+	if (index >= block->count)
+		return NULL;
+
+	entry = &block->entries[index];
+	*size = entry->size;
+
+	if (name)
+		*name = entry->name;
+
+	return entry->data;
+}
+
+const uint8_t* yarc_block_find(yarc_block_t* block, const char* name, uint32_t* size)
+{
+	uint32_t index;
+	yarc_entry_t* entry;
+
+	for (index = 0; index < block->count; index++)
+	{
+		entry = &block->entries[index];
+
+		if (!strcmp(name, entry->name))
+		{
+			*size = entry->size;
+			return entry->data;
+		}
+	}
+
+	return NULL;
+}
+
+yarc_block_t* yarc_block_open(const uint8_t* blockData, size_t blockSize)
+{
+	int zstatus;
+	uint32_t index;
+	yarc_block_t* block;
+	yarc_entry_t* entry;
+	const uint8_t* body;
+	const uint8_t* ptr = blockData;
+
+	block = (yarc_block_t*) malloc(sizeof(yarc_block_t));
+
+	if (!block)
+		return NULL;
+
+	if (blockSize < 24)
+		return NULL;
+
+	block->magic = *((uint32_t*) &ptr[0]);
+	block->offset = *((uint32_t*) &ptr[4]);
+	block->size = *((uint32_t*) &ptr[8]);
+	block->zsize = *((uint32_t*) &ptr[12]);
+	block->count = *((uint32_t*) &ptr[16]);
+	block->flags = *((uint32_t*) &ptr[20]);
+	ptr += 24;
+
+	if (block->magic != YARC_MAGIC)
+		return NULL;
+
+	ptr += yarc_string_read(ptr, blockSize - (ptr - blockData), &block->name);
+	block->name = _strdup(block->name);
+
+	block->data = (unsigned char*) malloc(block->size);
+
+	if (!block->data)
+		return NULL;
+
+	body = &blockData[block->offset];
+
+	if (block->zsize)
+	{
+		if ((block->offset + block->zsize) > blockSize)
+			return false;
+
+		zstatus = LZ4_decompress_safe((const char*) body, (char*) block->data, block->zsize, block->size);
+
+		if (zstatus != block->size)
+			return NULL;
+	}
+	else
+	{
+		if ((block->offset + block->size) > blockSize)
+			return NULL;
+
+		memcpy(block->data, body, block->size);
+	}
+
+	block->entries = (yarc_entry_t*) calloc(block->count, sizeof(yarc_entry_t));
+
+	if (!block->entries)
+		return NULL;
+
+	for (index = 0; index < block->count; index++)
+	{
+		entry = &block->entries[index];
+		
+		entry->offset = *((uint32_t*) &ptr[0]);
+		entry->size = *((uint32_t*) &ptr[4]);
+		ptr += 8;
+
+		ptr += yarc_string_read(ptr, blockSize - (ptr - blockData), &entry->name);
+		entry->name = _strdup(entry->name);
+
+		entry->data = &block->data[entry->offset];
+	}
+
+	return block;
+}
+
+void yarc_block_close(yarc_block_t* block)
+{
+	uint32_t index;
+	yarc_entry_t* entry;
+
+	if (!block)
+		return;
+
+	free((void*) block->name);
+	free(block->data);
+
+	for (index = 0; index < block->count; index++)
+	{
+		entry = &block->entries[index];
+		free((void*) entry->name);
+	}
+
+	free(block->entries);
+	free(block);
+}


### PR DESCRIPTION
Add support for block format, which does not use compiled source code to find resources. Instead, the block can be inserted in an executable segment, and loaded at runtime.